### PR TITLE
Use the package installation scripts and set up sudo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,22 @@
 FROM vcatechnology/centos
 MAINTAINER VCA Technology <developers@vcatechnology.com>
 
+# Build-time metadata as defined at http://label-schema.org
+ARG PROJECT_NAME
+ARG BUILD_DATE
+ARG VCS_REF
+ARG VERSION
+LABEL org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.name="$PROJECT_NAME" \
+      org.label-schema.description="An up-to-date CentOS image that has basic build tools installed" \
+      org.label-schema.url="https://www.debian.org/" \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.vcs-url="https://github.com/vcatechnology/docker-centos-ci" \
+      org.label-schema.vendor="VCA Technology" \
+      org.label-schema.version=$VERSION \
+      org.label-schema.license=MIT \
+      org.label-schema.schema-version="1.0"
+
 # Install useful packages
 RUN vca-install-package \
   python \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN sed -i "s|^.*requiretty|#Defaults requiretty|" /etc/sudoers
 
 # Grab the VCA CI Scripts
 RUN vca-install-package wget && \
-  wget https://tool-chain.vcatechnology.com/release/vca-tool-chain-ci-scripts-latest.tar.xz && \
+  wget -q https://tool-chain.vcatechnology.com/release/vca-tool-chain-ci-scripts-latest.tar.xz && \
   tar -Jxf vca-tool-chain-ci-scripts-latest.tar.xz -C / && \
   rm vca-tool-chain-ci-scripts-latest.tar.xz && \
   vca-uninstall-package wget

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,26 @@
-FROM vcatechnology/centos:latest
+FROM vcatechnology/centos
 MAINTAINER VCA Technology <developers@vcatechnology.com>
 
 # Install useful packages
-RUN yum install -y \
+RUN vca-install-package \
   python \
   git \
-  sudo 
+  sudo
 
-# grab the VCA CI Scripts
-RUN yum install -y wget && \
+# Grab the VCA CI Scripts
+RUN vca-install-package wget && \
   wget https://tool-chain.vcatechnology.com/release/vca-tool-chain-ci-scripts-latest.tar.xz && \
   tar -Jxf vca-tool-chain-ci-scripts-latest.tar.xz -C / && \
   rm vca-tool-chain-ci-scripts-latest.tar.xz && \
-  yum remove -y wget
+  vca-uninstall-package wget
 
-# create a build-server user with sudo permissions & no password
+# Create a build-server user with sudo permissions & no password
 RUN useradd -ms /bin/bash build-server && \
     echo "build-server ALL=(root) NOPASSWD:ALL" | tee -a /etc/sudoers.d/build-server && \
     echo "#includedir /etc/sudoers.d" >> /etc/sudoers && \
     chmod 755 /etc/sudoers.d && \
     chmod 0440 /etc/sudoers.d/build-server
 
-# set the build-server user as default
+# Set the build-server user as default
 WORKDIR /builds
 USER build-server

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,9 @@ RUN vca-install-package \
   python \
   git \
   sudo
+  
+# Allow sudo to run under Docker
+RUN sed -i "s|^.*requiretty|#Defaults requiretty|" /etc/sudoers
 
 # Grab the VCA CI Scripts
 RUN vca-install-package wget && \


### PR DESCRIPTION
Uses the optimal package installation to keep the image as small as possible. It also removes the `requiretty` option from the `/etc/sudoers` file so that it can be used correctly in Docker.